### PR TITLE
allow dots in thumb path or filename

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -7,7 +7,8 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- if not ($.Page.Scratch.Get "figurecount") }}<link rel="stylesheet" href="/css/hugo-easy-gallery.css" />{{ end }}
 {{- $.Page.Scratch.Add "figurecount" 1 -}}
 <!-- use either src or link-thumb for thumbnail image -->
-{{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}
+{{- $filetype := index (findRE "[^.]+$" (.Get "link") ) 0 }}
+{{- $thumb := .Get "src" | default (printf "%s.%s" (replaceRE "\\.[^.]+$" (.Get "thumb") (.Get "link") ) $filetype )  | relURL }}
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
     <div class="img"{{ if .Parent }} style="background-image: url('{{ print .Site.BaseURL $thumb }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -7,36 +7,36 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- $.Page.Scratch.Add "figurecount" 1 }}
 {{ $baseURL := .Site.BaseURL }}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
-	{{- with (.Get "dir") -}}
-		<!-- If a directory was specified, generate figures for all of the images in the directory -->
-		{{- $files := readDir (print "/static/" .) }}
-		{{- range $files -}}
-			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
-			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
-			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
-			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
-			{{- if and $isimg (not $isthumb) }}
-				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
-				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
+  {{- with (.Get "dir") -}}
+    <!-- If a directory was specified, generate figures for all of the images in the directory -->
+    {{- $files := readDir (print "/static/" .) }}
+    {{- range $files -}}
+      <!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
+      {{- $thumbext := $.Get "thumb" | default "-thumb" }}
+      {{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
+      {{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
+      {{- if and $isimg (not $isthumb) }}
+        {{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
+        {{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
         {{- $filetype := index (findRE "[^.]+$" .Name ) 0 }}<!-- file extension of image -->
         {{- $thumb := .Name | replaceRE "\\.[^.]+$" (printf "%s.%s" $thumbext $filetype) }}<!-- filename of thumbnail image -->
-				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
-				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
-				<div class="box">
-				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
-				      <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
-				    </div>
-			      <figcaption>
-		          <p>{{ $caption }}</p>
-			      </figcaption>
-				    <a href="{{ $linkURL }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
-				  </figure>
-				</div>
-			{{- end }}
-		{{- end }}
-	{{- else -}}
-		<!-- If no directory was specified, include any figure shortcodes called within the gallery -->
-	  {{ .Inner }}
-	{{- end }}
+        {{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
+        {{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
+        <div class="box">
+          <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+            <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
+              <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
+            </div>
+            <figcaption>
+              <p>{{ $caption }}</p>
+            </figcaption>
+            <a href="{{ $linkURL }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
+          </figure>
+        </div>
+      {{- end }}
+    {{- end }}
+  {{- else -}}
+    <!-- If no directory was specified, include any figure shortcodes called within the gallery -->
+    {{ .Inner }}
+  {{- end }}
 </div>

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -18,7 +18,8 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 			{{- if and $isimg (not $isthumb) }}
 				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
 				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
-				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
+        {{- $filetype := index (findRE "[^.]+$" .Name ) 0 }}<!-- file extension of image -->
+        {{- $thumb := .Name | replaceRE "\\.[^.]+$" (printf "%s.%s" $thumbext $filetype) }}<!-- filename of thumbnail image -->
 				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
 				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
 				<div class="box">


### PR DESCRIPTION
Thx for hugo-easy-gallery! Awesome!

I fixed an issue with the shortcodes (figure.html, gallery.html)
**When a path or filename includes dot(s) a wrong thumb filename is assumed.**

```
static/
├── css
│   └── hugo-easy-gallery.css
├── img
│   ├── gohugo.io
│   │   ├── hugo.ipsum.png
│   │   └── hugo.ipsum-thumb.png
│   ├── hugo-dolor.png
│   ├── hugo-dolor-thumb.png
│   ├── hugo.lorem.png
│   └── hugo.lorem-thumb.png
└── js
    └── load-photoswipe.js

```
e.g.
{{< figure thumb="-thumb" link="/img/hugo.lorem.png" size="400x400" >}}
gives:
 <img itemprop="thumbnail" src="/img/hugo-thumb.lorem-thumb.png"
instead of
 <img itemprop="thumbnail" src="/img/hugo.lorem-thumb.png"

Test site is here:
https://github.com/it-gro/HugoTestingHegDotIssue
(using blank as theme)

I untabified gallery.html as well - but commited separately.

Thx again!



