### PR TITLE
Issue figure attr

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -14,15 +14,13 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}
-    {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
+    {{- if or (or (.Get "title") (.Get "caption")) (or (.Get "attr") (.Get "attrlink"))  }}
       <figcaption>
         {{- with .Get "title" }}<h4>{{.}}</h4>{{ end }}
-        {{- if or (.Get "caption") (.Get "attr")}}
-          <p>
-            {{- .Get "caption" -}}
-            {{- with .Get "attrlink"}}<a href="{{.}}">{{ .Get "attr" }}</a>{{ else }}{{ .Get "attr"}}{{ end -}}
-          </p>
-        {{- end }}
+        {{- with .Get "caption" }}<p>{{.}}</p>{{ end }}
+        {{- if or (.Get "attr") (.Get "attrlink") }}
+			  <footer><small>{{if .Get "attrlink"}}<a href="{{.Get `attrlink`}}">{{ default (.Get "attrlink") (.Get "attr") }}</a>{{ else }}{{ .Get "attr"}}{{ end }}</small></footer>
+			  {{- end }}
       </figcaption>
     {{- end }}
   </figure>

--- a/layouts/shortcodes/load-photoswipe-theme.html
+++ b/layouts/shortcodes/load-photoswipe-theme.html
@@ -25,6 +25,15 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe-ui-default.min.js" integrity="sha256-PWHOlUzc96pMc8ThwRIXPn8yH4NOLu42RQ0b9SpnpFk=" crossorigin="anonymous"></script>
 -->
 
+<style>
+	  .pswp__caption a
+	, .pswp__caption small a
+	, .pswp__caption__center a {
+			/* text-decoration: none; */
+			color: #CCC;
+	}
+</style>
+
 <!-- Root element of PhotoSwipe. Must have class pswp. -->
 <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
 <!-- Background of PhotoSwipe.

--- a/layouts/shortcodes/load-photoswipe-theme.html
+++ b/layouts/shortcodes/load-photoswipe-theme.html
@@ -26,12 +26,12 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 -->
 
 <style>
-	  .pswp__caption a
-	, .pswp__caption small a
-	, .pswp__caption__center a {
-			/* text-decoration: none; */
-			color: #CCC;
-	}
+    .pswp__caption a
+  , .pswp__caption small a
+  , .pswp__caption__center a {
+      color: #CCC;
+      /* text-decoration: none; */
+  }
 </style>
 
 <!-- Root element of PhotoSwipe. Must have class pswp. -->

--- a/layouts/shortcodes/load-photoswipe.html
+++ b/layouts/shortcodes/load-photoswipe.html
@@ -13,7 +13,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 - If your template already loads jQuery in the footer, then you could load load-photoswipe.js from the footer instead
 -->
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
-<script src="/js/load-photoswipe2.js"></script>
+<script src="/js/load-photoswipe.js"></script>
 
 <!-- Photoswipe css/js libraries -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.css" integrity="sha256-sCl5PUOGMLfFYctzDW3MtRib0ctyUvI9Qsmq2wXOeBY=" crossorigin="anonymous" />
@@ -22,12 +22,12 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe-ui-default.min.js" integrity="sha256-PWHOlUzc96pMc8ThwRIXPn8yH4NOLu42RQ0b9SpnpFk=" crossorigin="anonymous"></script>
 
 <style>
-	  .pswp__caption a
-	, .pswp__caption small a
-	, .pswp__caption__center a {
-			/* text-decoration: none; */
-			color: #CCC;
-	}
+    .pswp__caption a
+  , .pswp__caption small a
+  , .pswp__caption__center a {
+      color: #CCC;
+      /* text-decoration: none; */
+  }
 </style>
 
 <!-- Root element of PhotoSwipe. Must have class pswp. -->

--- a/layouts/shortcodes/load-photoswipe.html
+++ b/layouts/shortcodes/load-photoswipe.html
@@ -13,13 +13,22 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 - If your template already loads jQuery in the footer, then you could load load-photoswipe.js from the footer instead
 -->
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
-<script src="/js/load-photoswipe.js"></script>
+<script src="/js/load-photoswipe2.js"></script>
 
 <!-- Photoswipe css/js libraries -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.css" integrity="sha256-sCl5PUOGMLfFYctzDW3MtRib0ctyUvI9Qsmq2wXOeBY=" crossorigin="anonymous" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/default-skin/default-skin.min.css" integrity="sha256-BFeI1V+Vh1Rk37wswuOYn5lsTcaU96hGaI7OUVCLjPc=" crossorigin="anonymous" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.js" integrity="sha256-UplRCs9v4KXVJvVY+p+RSo5Q4ilAUXh7kpjyIP5odyc=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe-ui-default.min.js" integrity="sha256-PWHOlUzc96pMc8ThwRIXPn8yH4NOLu42RQ0b9SpnpFk=" crossorigin="anonymous"></script>
+
+<style>
+	  .pswp__caption a
+	, .pswp__caption small a
+	, .pswp__caption__center a {
+			/* text-decoration: none; */
+			color: #CCC;
+	}
+</style>
 
 <!-- Root element of PhotoSwipe. Must have class pswp. -->
 <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">

--- a/static/css/hugo-easy-gallery.css
+++ b/static/css/hugo-easy-gallery.css
@@ -162,7 +162,7 @@ figure img {
 }
 
 figure figcaption a {
-		position: relative;
-		color: #CCC;
-		/* text-decoration: none; */
+    position: relative;
+    color: #CCC;
+    /* text-decoration: none; */
 }

--- a/static/css/hugo-easy-gallery.css
+++ b/static/css/hugo-easy-gallery.css
@@ -157,3 +157,12 @@ figcaption p {
     margin: auto; /* override style in theme */
 }
 
+figure img {
+    max-width: 100%;
+}
+
+figure figcaption a {
+		position: relative;
+		color: #CCC;
+		/* text-decoration: none; */
+}

--- a/static/js/load-photoswipe.js
+++ b/static/js/load-photoswipe.js
@@ -17,35 +17,40 @@ $( document ).ready(function() {
 	var items = []; // array of slide objects that will be passed to PhotoSwipe()
 	// for every figure element on the page:
 	$('figure').each( function() {
-		if ($(this).attr('class') == 'no-photoswipe') return true; // ignore any figures where class="no-photoswipe"
-		// get properties from child a/img/figcaption elements,
-		var $figure = $(this),
-			$a 		= $figure.find('a'),
-			$img 	= $figure.find('img'),
-			$src	= $a.attr('href'),
-			$title  = $img.attr('alt'),
-			$msrc	= $img.attr('src');
-		// if data-size on <a> tag is set, read it and create an item
-		if ($a.data('size')) {
-			var $size 	= $a.data('size').split('x');
-			var item = {
-				src		: $src,
-				w		: $size[0],
-				h 		: $size[1],
-				title 	: $title,
-				msrc	: $msrc
-			};
-			console.log("Using pre-defined dimensions for " + $src);
-		// if not, set temp default size then load the image to check actual size
-		} else {
-			var item = {
-				src		: $src,
-				w		: 800, // temp default size
-				h 		: 600, // temp default size
-				title 	: $title,
-				msrc	: $msrc
-			};
-			console.log("Using default dimensions for " + $src);
+    if ($(this).attr('class') == 'no-photoswipe') return true; // ignore any figures where class="no-photoswipe"
+    // get properties from child a/img/figcaption elements,
+    var $figure = $(this)
+      $a            = $figure.find('a')
+    , $img          = $figure.find('div').find('img')
+    , $footer       = $figure.find('figcaption').find('footer')
+    , $footer_text  = ($footer.find('a').length ? ($footer.find('a').text().length ? $footer.find('a').text() : $footer.find('a').attr('href') )  :  $footer.text() )
+    , $footer_href  = ($footer.find('a').length ? $footer.find('a').attr('href')  : null)
+    , $title_footer = ($footer_href != null ? "<a href=" + $footer_href + ">"+$footer_text+"</a>" : $footer_text)
+    , $src          = $a.attr('href')
+    , $title        = $img.attr('alt')
+    , $msrc         = $img.attr('src')
+    ;
+    // if data-size on <a> tag is set, read it and create an item
+    if ($a.data('size')) {
+      var $size = $a.data('size').split('x');
+      var item = {
+          src   : $src
+        , w     : $size[0]
+        , h     : $size[1]
+        , title : ($title ? $title : "") + ($title_footer ? ($title ? "<br/><small>" : "") + $title_footer + ($title ? "</small>" : "" ) : "")
+        , msrc  : $msrc
+      };
+      console.log("Using pre-defined dimensions for " + $src);
+      // if not, set temp default size then load the image to check actual size
+    } else {
+      var item = {
+          src   : $src
+        , w     : 800 // temp default size
+        , h     : 600 // temp default size
+        , title : ($title ? $title : "") + ($title_footer ? ($title ? "<br/><small>" : "") + $title_footer + ($title ? "</small>" : "" ) : "")
+        , msrc  : $msrc
+      };
+      console.log("Using default dimensions for " + $src);
 			// load the image to check its dimensions
 			// update the item as soon as w and h are known (check every 30ms)
 			var img = new Image(); 


### PR DESCRIPTION
Hi Yip
Here's another one (now using a branch).
There's an **issue with the figure attributes attr and attrlink.**
`{{< figure thumb="-thumb" link="/img/hugo-dolor.png" size="900x450" caption="foo" attr="(c) by bar" attrlink="https://www.example.com" >}}
`
leads to an error:
`ERROR 2018/01/10 15:07:44 error processing shortcode "shortcodes/figure.html" for page "post/test-heg-figure-attrlink.md": template: shortcodes/figure.html:23:57: executing "shortcodes/figure.html" at <.Get>: can't evaluate field Get in type string
`
I fixed that and improved the captions. If a figure has an attribution it needs to be shown:
https://stackoverflow.com/questions/21483356/how-to-mark-the-copyright-of-an-image-in-html

So I did:
figure.html:
```
        {{- if or (.Get "attr") (.Get "attrlink") }}
			  <footer><small>{{if .Get "attrlink"}}<a href="{{.Get `attrlink`}}">{{ default (.Get "attrlink") (.Get "attr") }}</a>{{ else }}{{ .Get "attr"}}{{ end }}</small></footer>

```
load-photoswipe.js: 
 `title : ($title ? $title : "") + ($title_footer ? ($title ? "<br/><small>" : "") + $title_footer + ($title ? "</small>" : "" ) : "")
`
load-photoswipe.html, load-photoswipe-theme.html, hugo-easy-gallery.css:
Adjust color for a tag
(Kind of ugly in the html files, maybe you see a better way)

hugo-easy-gallery.css I did ad well:
```
figure img {
    max-width: 100%;
}
```
You have this in https://www.liwen.id.au/css/main.css as well. 
Without it, the thumbs are cropped. It took me a while until I figured that on out.

Test site:
https://github.com/it-gro/HugoTestingHegAttrIssue

Kind regards





