### PR TITLE
Look for thumbnails also in the content folder

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -10,6 +10,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 	{{- with (.Get "dir") -}}
 		<!-- If a directory was specified, generate figures for all of the images in the directory -->
 		{{- $files := readDir (print "/static/" .) }}
+		{{- $contentFiles := readDir (print "/content/" .) }}
 		{{- range $files -}}
 			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
 			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
@@ -19,7 +20,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
 				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
 				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
-				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
+				{{- $thumbexists := or (where $files "Name" $thumb) (where $contentFiles "Name" $thumb) }}<!-- does a thumbnail image exist? -->
 				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
 				<div class="box">
 				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">


### PR DESCRIPTION
This is convenient to keep static and content separated if you use an
external script for the thumbnails generation.