### PR TITLE
Make dir relative to page and auto-generate thumbnails

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -5,37 +5,30 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->
 {{- if not ($.Page.Scratch.Get "figurecount") }}<link rel="stylesheet" href="/css/hugo-easy-gallery.css" />{{ end }}
 {{- $.Page.Scratch.Add "figurecount" 1 }}
-{{ $baseURL := .Site.BaseURL }}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
 	{{- with (.Get "dir") -}}
 		<!-- If a directory was specified, generate figures for all of the images in the directory -->
-		{{- $files := readDir (print "/static/" .) }}
+		{{- $files := $.Page.Resources.Match (path.Join . "/*.{gif,jpg,jpeg,tiff,png,bmp}") }}
 		{{- range $files -}}
-			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
-			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
-			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
-			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
-			{{- if and $isimg (not $isthumb) }}
-				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
-				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
-				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
-				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
-				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
-				<div class="box">
-				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
-				      <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
-				    </div>
-			      <figcaption>
-		          <p>{{ $caption }}</p>
-			      </figcaption>
-				    <a href="{{ $linkURL }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
-				  </figure>
-				</div>
+			{{- $caption :=  .Name | path.Base | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
+			{{- with .Title }}
+				{{- $caption :=  . }}
 			{{- end }}
-		{{- end }}
+			{{- $thumb := .Fill "300x300 q90 center" }}<!-- thumbnail image -->
+	<div class="box">
+		<figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+			<div class="img" style="background-image: url('{{ $thumb.RelPermalink }}');" >
+				<img itemprop="thumbnail" src="{{ $thumb.RelPermalink }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
+			</div>
+			<figcaption>
+				<p>{{ $caption }}</p>
+			</figcaption>
+			<a href="{{ .RelPermalink }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
+		</figure>
+	</div>
+			{{- end }}
 	{{- else -}}
 		<!-- If no directory was specified, include any figure shortcodes called within the gallery -->
-	  {{ .Inner }}
+		{{ .Inner }}
 	{{- end }}
 </div>


### PR DESCRIPTION
Thanks for this great project!

I would like to suggest the following changes:
 - Use [page resources](https://gohugo.io/content-management/page-resources/) to organize is really nice and clean. That's why `dir` is relative to the page directory now.
- Automatic creation of thumbnails makes this even more nice and easy thanks to the [image processing
feature](https://gohugo.io/content-management/image-processing/).