### PR TITLE
Avoid doubled thumbnail downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # hugo-easy-gallery
+
+**2019-01-20: I'm looking for people to help maintain this project - e.g. review and approve pull requests, which I no longer have time to do. Please contact me if you are interested. Thanks!**
+
 Automagical css image gallery in [Hugo](https://gohugo.io/) using shortcodes, with optional lightbox/carousel gadget using [PhotoSwipe](http://photoswipe.com/) and jQuery.
 
 **New:** Create a gallery of all images in a directory with just one line of shortcode, see [demo](https://www.liwen.id.au/heg/#gallery-usage).

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -10,8 +10,9 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-    <div class="img"{{ if .Parent }} style="background-image: url('{{ (print .Site.BaseURL $thumb) | replaceRE "([^:]/)/" "$1" }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
-      <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
+    <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb | relURL }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
+
+      <img itemprop="thumbnail" src="{{ $thumb | relURL }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -11,7 +11,6 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
     <div class="img"{{ if .Parent }} style="background-image: url('{{ (print .Site.BaseURL $thumb) | replaceRE "([^:]/)/" "$1" }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
-
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -10,7 +10,8 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- $thumb := .Get "src" | default (printf "%s." (.Get "thumb") | replace (.Get "link") ".") }}
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-    <div class="img"{{ if .Parent }} style="background-image: url('{{ print .Site.BaseURL $thumb }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
+    <div class="img"{{ if .Parent }} style="background-image: url('{{ (print .Site.BaseURL $thumb) | replaceRE "([^:]/)/" "$1" }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
+
       <img itemprop="thumbnail" src="{{ $thumb }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -11,7 +11,6 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 <div class="box{{ with .Get "caption-position" }} fancy-figure caption-position-{{.}}{{end}}{{ with .Get "caption-effect" }} caption-effect-{{.}}{{end}}" {{ with .Get "width" }}style="max-width:{{.}}"{{end}}>
   <figure {{ with .Get "class" }}class="{{.}}"{{ end }} itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
     <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb | relURL }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
-
       <img itemprop="thumbnail" src="{{ $thumb | relURL }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
     {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}


### PR DESCRIPTION
This change avoids downloading the thumbnails two times because of different URLs for the background images and the thumbnails themselves.

Possibly the problem arises only when not using the directory directive and using absolute paths in the figure tags. When using absolute paths the background image gets a doubled slash (from baseURL and thumbnail path). Reason for the doubled image download is the different construction of the URL for the thumbnail itself and for the background image. A possible (alternative) fix might also be to use the same URL in both places.

Demo page:  https://xenodochial-bose-2fedbb.netlify.com/2018/12/photoshoot-business/

Fixed page: https://frank.tegtmeyer.net/2018/12/photoshoot-business/


Source code:

`{{< gallery >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-yXrV-thumb.jpg" size="1333x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-yXrV.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-182N-thumb.jpg" size="1333x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-182N.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-J42B-thumb.jpg" size="2000x1333" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-J42B.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-aM69-thumb.jpg" size="1333x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-aM69.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-vPkv-thumb.jpg" size="1333x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-vPkv.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-XWoD-thumb.jpg" size="1333x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-XWoD.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-oeqJ-thumb.jpg" size="2000x1333" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-oeqJ.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-vPwa-thumb.jpg" size="2000x1696" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-vPwa.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-DYyo-thumb.jpg" size="1236x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-DYyo.jpg" >}}
  {{< figure src="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-x33r-thumb.jpg" size="2000x2000" link="/img/2018/12/Frank_Tegtmeyer__Portrait-2017-x33r.jpg" >}}
{{< /gallery >}}

{{< load-photoswipe >}}
`

Check of the results (in the waterfall tab):

https://gtmetrix.com/reports/frank.tegtmeyer.net/P2sLfkYN (fixed version)
https://gtmetrix.com/reports/xenodochial-bose-2fedbb.netlify.com/fQSx5X9q (unfixed version)

I checked the doubled download in Safari - the developer tools show that the thumbnails are downloaded twice in the unpatched version.

Regards, Frank