### PR TITLE
Use page resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Automagical css image gallery in [Hugo](https://gohugo.io/) using shortcodes, wi
 - Put multiple `{{< figure >}}` shortcodes inside a `{{< gallery >}}` to create a pretty image gallery
 - **Point `{{< gallery >}}` at a directory to generate a gallery of all images in that directory**
 - Gallery is responsive, images are scaled/cropped to fill square (or other evenly-sized) tiles
-- Pretty captions appear/slide/fade upon hovering over the image 
+- Pretty captions appear/slide/fade upon hovering over the image
 - Optionally make gallery images zoom, grow, shrink, slide up, or slide down upon hover
 - Only requires 3.6kB of CSS (unminified; you can minify it if you want)
 - CSS is automatically loaded the first time you use the `{{< figure >}}` shortcode on each page
@@ -92,10 +92,10 @@ Optional parameters:
 - `size` (e.g. `size="1024x768"`) pre-defines the image size for PhotoSwipe. Use this option if you don't want to pre-load the linked image to determine its size.
 - `class` allows you to set any custom classes you want on the `<figure>` tag.
 
-Optional parameters for standalone `{{< figure >}}` shortcodes only (i.e. don't use on `{{< figure >}}` inside `{{< gallery >}}` - strange things may happen if you do): 
+Optional parameters for standalone `{{< figure >}}` shortcodes only (i.e. don't use on `{{< figure >}}` inside `{{< gallery >}}` - strange things may happen if you do):
 
-- `caption-position` and `caption-effect` work the same as for the `{{< gallery >}}` shortcode (see below). 
-- `width` defines the [`max-width`](https://www.w3schools.com/cssref/pr_dim_max-width.asp) of the image displayed on the page. If using a thumbnail for a standalone figure, set this equal to your thumbnail's native width to make the captions behave properly (or feel free to come up with a better solution and submit a pull request :-)). Also use this option if you don't have a thumbnail and you don't want the hi-res image to take up the entire width of the screen/container. 
+- `caption-position` and `caption-effect` work the same as for the `{{< gallery >}}` shortcode (see below).
+- `width` defines the [`max-width`](https://www.w3schools.com/cssref/pr_dim_max-width.asp) of the image displayed on the page. If using a thumbnail for a standalone figure, set this equal to your thumbnail's native width to make the captions behave properly (or feel free to come up with a better solution and submit a pull request :-)). Also use this option if you don't have a thumbnail and you don't want the hi-res image to take up the entire width of the screen/container.
 - `class="no-photoswipe"` prevents a `<figure>` from being loaded into PhotoSwipe. If you click on the figure you'll instead a good ol' fashioned hyperlink to a bigger image (or - if you haven't specified a bigger image - the same one).
 
 ## `{{< gallery >}}` shortcode usage
@@ -141,6 +141,8 @@ Optional parameters:
 - `hover-transition` - determines if/how images change upon hover. Options:
   - not set - smooth transition (default)
   - `none` - hard transition
+- `thumbnail-size` sets the size of the thumbnails for the gallery. Default is "300x300". First number is width, second number is height.
+  - example: `{{< gallery dir="/img/your-directory-of-images/" thumbnail-size="150x150" />}}`
 
 ## PhotoSwipe usage
 

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -6,10 +6,12 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- if not ($.Page.Scratch.Get "figurecount") -}}<link rel="stylesheet" href="/css/hugo-easy-gallery.css" />{{- end -}}
 {{- $.Page.Scratch.Add "figurecount" 1 -}}
 {{- $baseURL := .Site.BaseURL -}}
+{{- $thumbnailSize := .Get "thumbnail-size" | default "300x300" -}}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
 	<!-- Generate figures for all page resources of type image. -->
 	{{- range $.Page.Resources.ByType "image" -}}
-		{{- $thumbnail := .Fill "300x300" -}}
+
+		{{- $thumbnail := .Fill $thumbnailSize -}}
 		<div class="box">
 			<figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
 				<div class="img" style="background-image: url('{{ $thumbnail.RelPermalink }}');" >

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -8,22 +8,56 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 {{- $baseURL := .Site.BaseURL -}}
 {{- $thumbnailSize := .Get "thumbnail-size" | default "300x300" -}}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
-	<!-- Generate figures for all page resources of type image. -->
-	{{- range $.Page.Resources.ByType "image" -}}
-
-		{{- $thumbnail := .Fill $thumbnailSize -}}
-		<div class="box">
-			<figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-				<div class="img" style="background-image: url('{{ $thumbnail.RelPermalink }}');" >
-					<img itemprop="thumbnail" src="{{ $thumbnail.RelPermalink }}" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" alt="{{ .Title }}" /><!-- <img> hidden if in .gallery -->
+	{{- with (.Get "dir") -}}
+		<!-- If a directory was specified, generate figures for all of the images in the directory -->
+		{{- $files := readDir (print "/static/" .) }}
+		{{- range $files -}}
+			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
+			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
+			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
+			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
+			{{- if and $isimg (not $isthumb) }}
+				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
+				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
+				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
+				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? -->
+				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
+				<div class="box">
+				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
+				      <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
+				    </div>
+			      <figcaption>
+		          <p>{{ $caption }}</p>
+			      </figcaption>
+				    <a href="{{ $linkURL }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
+				  </figure>
 				</div>
-				{{- with .Title -}}
-				<figcaption>
-					<p>{{ . }}</p>
-				</figcaption>
-				{{- end -}}
-				<a href="{{ .RelPermalink }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
-			</figure>
-		</div>
+			{{- end }}
+		{{- end }}
+	{{- else }}
+		{{ with .Inner -}}
+			<!-- If no directory was specified, include any figure shortcodes called within the gallery -->
+			{{ . }}
+		{{- else }}
+			<!-- Generate figures for all page resources of type image. -->
+			{{- range $.Page.Resources.ByType "image" -}}
+
+				{{- $thumbnail := .Fill $thumbnailSize -}}
+				<div class="box">
+					<figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+						<div class="img" style="background-image: url('{{ $thumbnail.RelPermalink }}');" >
+							<img itemprop="thumbnail" src="{{ $thumbnail.RelPermalink }}" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" alt="{{ .Title }}" /><!-- <img> hidden if in .gallery -->
+						</div>
+						{{- with .Title -}}
+						<figcaption>
+							<p>{{ . }}</p>
+						</figcaption>
+						{{- end -}}
+						<a href="{{ .RelPermalink }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
+					</figure>
+				</div>
+			{{- end }}
+		{{- end }}
 	{{- end }}
 </div>

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -3,39 +3,25 @@ Put this file in /layouts/shortcodes/gallery.html
 Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 -->
 <!-- count how many times we've called this shortcode; load the css if it's the first time -->
-{{- if not ($.Page.Scratch.Get "figurecount") }}<link rel="stylesheet" href="/css/hugo-easy-gallery.css" />{{ end }}
-{{- $.Page.Scratch.Add "figurecount" 1 }}
-{{ $baseURL := .Site.BaseURL }}
+{{- if not ($.Page.Scratch.Get "figurecount") -}}<link rel="stylesheet" href="/css/hugo-easy-gallery.css" />{{- end -}}
+{{- $.Page.Scratch.Add "figurecount" 1 -}}
+{{- $baseURL := .Site.BaseURL -}}
 <div class="gallery caption-position-{{ with .Get "caption-position" | default "bottom" }}{{.}}{{end}} caption-effect-{{ with .Get "caption-effect" | default "slide" }}{{.}}{{end}} hover-effect-{{ with .Get "hover-effect" | default "zoom" }}{{.}}{{end}} {{ if ne (.Get "hover-transition") "none" }}hover-transition{{end}}" itemscope itemtype="http://schema.org/ImageGallery">
-	{{- with (.Get "dir") -}}
-		<!-- If a directory was specified, generate figures for all of the images in the directory -->
-		{{- $files := readDir (print "/static/" .) }}
-		{{- range $files -}}
-			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
-			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
-			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
-			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
-			{{- if and $isimg (not $isthumb) }}
-				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
-				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->
-				{{- $thumb := .Name | replaceRE "(\\.)" ($thumbext | printf "%s.") }}<!-- filename of thumbnail image -->
-				{{- $thumbexists := where $files "Name" $thumb }}<!-- does a thumbnail image exist? --> 
-				{{- $thumbURL := print $baseURL ($.Get "dir") "/" $thumb | absURL }}<!-- absolute URL to thumbnail image -->
-				<div class="box">
-				  <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
-				    <div class="img" style="background-image: url('{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}');" >
-				      <img itemprop="thumbnail" src="{{ if $thumbexists }}{{ $thumbURL }}{{ else }}{{ $linkURL }}{{ end }}" alt="{{ $caption }}" /><!-- <img> hidden if in .gallery -->
-				    </div>
-			      <figcaption>
-		          <p>{{ $caption }}</p>
-			      </figcaption>
-				    <a href="{{ $linkURL }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
-				  </figure>
+	<!-- Generate figures for all page resources of type image. -->
+	{{- range $.Page.Resources.ByType "image" -}}
+		{{- $thumbnail := .Fill "300x300" -}}
+		<div class="box">
+			<figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
+				<div class="img" style="background-image: url('{{ $thumbnail.RelPermalink }}');" >
+					<img itemprop="thumbnail" src="{{ $thumbnail.RelPermalink }}" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" alt="{{ .Title }}" /><!-- <img> hidden if in .gallery -->
 				</div>
-			{{- end }}
-		{{- end }}
-	{{- else -}}
-		<!-- If no directory was specified, include any figure shortcodes called within the gallery -->
-	  {{ .Inner }}
+				{{- with .Title -}}
+				<figcaption>
+					<p>{{ . }}</p>
+				</figcaption>
+				{{- end -}}
+				<a href="{{ .RelPermalink }}" itemprop="contentUrl"></a><!-- put <a> last so it is stacked on top -->
+			</figure>
+		</div>
 	{{- end }}
 </div>


### PR DESCRIPTION
Hi! Thanks a lot for this shortcode, it's very useful!

I did a complete overhaul to make use of [Hugo Page Resources](https://gohugo.io/content-management/page-resources/) which makes ranging over files to make a gallery a lot easier.

The gallery shortcode can now also create thumbnails on the fly, with a configurable thumbnail size, for example: `{{< gallery dir="/img/your-directory-of-images/" thumbnail-size="150x150" />}}`. The parameter for thumbnail size is not mandatory: the shortcode defaults to 300x300.

I'm already using this updated version on [my site](https://www.emielhollander.nl), except for the configurable thumbnail size, which I added today.

I would also be willing to help maintain this project. Let me know if you would like my help!