### PR TITLE
Fix image 404 on sites with paths in URL

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -13,7 +13,7 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
     <div class="img"{{ if .Parent }} style="background-image: url('{{ $thumb | relURL }}');"{{ end }}{{ with .Get "size" }} data-size="{{.}}"{{ end }}>
       <img itemprop="thumbnail" src="{{ $thumb | relURL }}" {{ with .Get "alt" | default (.Get "caption") }}alt="{{.}}"{{ end }}/><!-- <img> hidden if in .gallery -->
     </div>
-    {{ with .Get "link" | default (.Get "src") }}<a href="{{.}}" itemprop="contentUrl"></a>{{ end }}
+    {{ with .Get "link" | default (.Get "src") }}<a href="{{ . | relURL }}" itemprop="contentUrl"></a>{{ end }}
     {{- if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
       <figcaption>
         {{- with .Get "title" }}<h4>{{.}}</h4>{{ end }}


### PR DESCRIPTION
I am using Hugo Easy Gallery on a site I am working on. Whenever I push changes to the site a Jenkins build is kicked off to create a staging site. The URL for the staging site contains a path in it using the name of the branch, i.e.:

http://someurl.com/somebranch/

This causes the images in the overlay to 404, while the thumbnail images display fine. 

The change I am proposing here seems to fix this issue, as my latest build works and the images in the overlay are no longer causing a 404. 