### PR TITLE
Add theme file for easy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Automagical css image gallery in [Hugo](https://gohugo.io/) using shortcodes, wi
 - Loads PhotoSwipe js and css libraries from `cdnjs.cloudflare.com`
 
 ## Installation
+### As a Theme
+Check out this repo into your `themes/` folder:
+
+```
+git submodule add git@github.com:liwenyip/hugo-easy-gallery.git themes/easy-gallery
+```
+
+Then update your `./config.toml` to load the theme, for example:
+
+```
+theme = ["hugo-coder", "easy-gallery"]
+```
+
+### Manual Installation
 Put files in following places:
 
 - /layouts/shortcodes/figure.html

--- a/theme.toml
+++ b/theme.toml
@@ -1,0 +1,10 @@
+name = "Easy Gallery"
+license = "MIT"
+licenselink = "https://github.com/liwenyip/hugo-easy-gallery/blob/master/LICENCE.md"
+description = "Automagical css image gallery in Hugo using shortcodes, with optional lightbox/carousel gadget using PhotoSwipe and jQuery."
+homepage = "https://github.com/liwenyip/hugo-easy-gallery"
+min_version = "0.79.0"
+
+[author]
+name = "Li-Wen Yip "
+homepage = "https://www.liwen.id.au/"


### PR DESCRIPTION
With the addition of a `theme.toml` file, it is now possible to install the add-on as a git submodule in the "standard" way. These are the new installation instructions:

Check out this repo into your `themes/` folder:

```
git submodule add git@github.com:liwenyip/hugo-easy-gallery.git themes/easy-gallery
```

Then update your `./config.toml` to load the theme, for example:

```
theme = ["hugo-coder", "easy-gallery"]
```