### PR TITLE
Include webp images in gallery

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -11,10 +11,10 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 		<!-- If a directory was specified, generate figures for all of the images in the directory -->
 		{{- $files := readDir (print "/static/" .) }}
 		{{- range $files -}}
-			<!-- skip files that aren't images, or that inlcude the thumb suffix in their name -->
+			<!-- skip files that aren't images, or that include the thumb suffix in their name -->
 			{{- $thumbext := $.Get "thumb" | default "-thumb" }}
 			{{- $isthumb := .Name | findRE ($thumbext | printf "%s\\.") }}<!-- is the current file a thumbnail image? -->
-			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp)" }}<!-- is the current file an image? -->
+			{{- $isimg := lower .Name | findRE "\\.(gif|jpg|jpeg|tiff|png|bmp|webp)" }}<!-- is the current file an image? -->
 			{{- if and $isimg (not $isthumb) }}
 				{{- $caption :=  .Name | replaceRE "\\..*" "" | humanize }}<!-- humanized filename without extension -->
 				{{- $linkURL := print $baseURL ($.Get "dir") "/" .Name | absURL }}<!-- absolute URL to hi-res image -->


### PR DESCRIPTION
All modern browsers [support webp now](https://caniuse.com/webp). Quoting [Google Lighthouse](https://developers.google.com/web/tools/lighthouse),

```
Image formats like WebP ... often provide better compression than PNG or JPEG,
which means faster downloads and less data consumption.
```

With that in mind, I think including files ending with ".webp" in the gallery makes sense!

Also fixed a typo in a comment.